### PR TITLE
Fix semver version format and enable npm publishing (develop → master)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-gl",
-  "version": "0.9.0.alpha.6",
+  "version": "0.9.0-alpha.6",
   "type": "module",
   "description": "A module for making it easier to use Esri services in mapbox-gl or maplibre-gl.",
   "main": "dist/esri-gl.js",


### PR DESCRIPTION
## Summary

This PR fixes the invalid semver version format that was causing npm publish failures.

## Problem Fixed

The version `"0.9.0.alpha.6"` in package.json was causing npm publish errors:
```
npm error Invalid version: "0.9.0.alpha.6"
```

## Solution

- **Fixed version format**: Changed from `"0.9.0.alpha.6"` to `"0.9.0-alpha.6"`
- **Follows semantic versioning**: Uses proper hyphen separator for prerelease versions
- **Enables publishing**: Allows npm publish commands to succeed

## Additional Changes Included

- Documentation restructuring and JSX syntax fixes
- GitHub Packages publishing workflows enhancement
- Netlify iframe embedding fix for documentation examples

## Branch Update

**Note:** The source branch has been renamed from `dev` to `develop` to follow conventional naming practices.

## Validation

After merging this PR, the following workflows should work correctly:
- ✅ `npm publish --tag alpha` 
- ✅ GitHub Packages publishing workflow
- ✅ Release workflow with proper semver handling

## Files Modified

- `package.json`: Corrected version format to valid semver
- Various documentation files with JSX fixes
- GitHub workflow enhancements for dual NPM/GitHub Packages publishing
- Netlify configuration for iframe support

This PR resolves the publishing pipeline issues and enables proper release management.