### PR TITLE
fix: resolve FeatureService race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-gl",
-  "version": "0.9.0-alpha.14",
+  "version": "0.9.0-alpha.15",
   "type": "module",
   "description": "A module for making it easier to use Esri services in mapbox-gl or maplibre-gl.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description
This PR fixes issue #10 - a race condition in the `FeatureService` that occurs when adding layers immediately after service creation.

## Problem
When creating a `FeatureService` instance, the source wasn't added to the map immediately because `_createSource()` is an async function that makes HTTP requests. This caused a race condition where attempting to add a layer immediately after creating the service would fail because the source didn't exist yet.

## Solution
Implemented a **`sourceReady` promise** that resolves when the source has been successfully added to the map. This allows developers to:

1. Create the service without blocking
2. Await the promise before adding layers that reference the source
3. Handle errors if source creation fails

## Changes
- Added `sourceReady: Promise<void>` public property to `FeatureService`
- Added private `_sourceReadyResolve` and `_sourceReadyReject` callbacks
- Modified constructor to initialize the `sourceReady` promise
- Updated `_createSource()` to resolve the promise when source is added successfully
- Updated error handling to reject the promise if source creation fails
- Added comprehensive JSDoc documentation with usage examples
- Added 3 new tests verifying the `sourceReady` promise functionality
- Updated existing error handling tests to properly handle promise rejections
- Bumped version from 0.9.0-alpha.14 to 0.9.0-alpha.15

## Usage Example
```typescript
const service = new FeatureService('my-source', map, { url: '...' });

// Wait for source to be ready before adding a layer
await service.sourceReady;
map.addLayer({
  id: 'my-layer',
  type: 'circle',
  source: 'my-source',
  paint: { 'circle-radius': 5, 'circle-color': '#007cbf' }
});
```

## Testing
- ✅ All 52 FeatureService tests pass
- ✅ All 640 tests across the entire suite pass
- ✅ TypeScript compilation passes with no errors
- ✅ ESLint checks pass
- ✅ Code formatting verified
- ✅ Build successful
- ✅ npm ci verified

## Checklist
- [x] Tests pass
- [x] Code is formatted
- [x] Build is successful
- [x] Documentation added
- [x] No breaking changes
- [x] Version bumped
