### PR TITLE
refactor: deduplicate react-map-gl layer components and services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+### Unreleased
+
+#### Internal Refactor — no public API changes
+- **react-map-gl layer components**: Extracted the "wait for map style load" effect into a shared `useMapLoaded` hook used by all five layer components. `EsriDynamicLayer`, `EsriTiledLayer`, and `EsriImageLayer` now share a `useRasterLayer` hook for service creation + raster-layer lifecycle.
+- **react-map-gl hooks**: `useEsriMapboxLayer` and `useEsriMaplibreLayer` now delegate to a shared `createEsriLayerHooks` factory — they differed only by which `useMap` implementation they imported.
+- **Services**: Added `removeMapSource` and `appendTokenIfExists` helpers in `utils.ts`; `DynamicMapService`, `TiledMapService`, `ImageService`, `VectorTileService`, and `FeatureService` `remove()` methods now share one implementation instead of five near-duplicates.
+- **Task hooks**: `useFind`, `useQuery`, `useIdentifyFeatures`, `useIdentifyImage`, and `useFeatureEditing` now share a `useAsyncOperation` hook that owns the loading/error state machine instead of each hook re-implementing the same `try/catch/finally` dance.
+- Net diff: **–430 lines** across layer components, services, and task hooks; 733/733 tests still pass; lint errors 1 → 0.
+
 ### v1.0.0
 **Stable Release**
 

--- a/src/Services/DynamicMapService.ts
+++ b/src/Services/DynamicMapService.ts
@@ -1,4 +1,11 @@
-import { cleanTrailingSlash, getServiceDetails, isAbortError, updateAttribution } from '@/utils';
+import {
+  appendTokenIfExists,
+  cleanTrailingSlash,
+  getServiceDetails,
+  isAbortError,
+  removeMapSource,
+  updateAttribution,
+} from '@/utils';
 import type {
   Map,
   EsriServiceOptions,
@@ -347,10 +354,7 @@ export class DynamicMapService {
   }
 
   private _appendTokenIfExists(params: URLSearchParams): void {
-    const token = (this.esriServiceOptions as any).token;
-    if (token) {
-      params.append('token', token);
-    }
+    appendTokenIfExists(params, (this.esriServiceOptions as { token?: string }).token);
   }
 
   private _escapeValue(val: unknown): string {
@@ -972,70 +976,6 @@ export class DynamicMapService {
   }
 
   remove(): void {
-    const map = this._map;
-    if (!map || typeof map.removeSource !== 'function') {
-      return;
-    }
-
-    try {
-      // Guard against map whose style has already been destroyed
-      if (!(map as unknown as { style?: unknown }).style) return;
-
-      const mapWithStyle = map as unknown as {
-        getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
-      };
-      const mapLayerApi = map as unknown as {
-        getLayer?: (id: string) => unknown;
-        removeLayer?: (id: string) => void;
-      };
-      const mapSourceApi = map as unknown as {
-        getSource?: (id: string) => unknown;
-      };
-
-      if (typeof mapWithStyle.getStyle === 'function') {
-        const style = mapWithStyle.getStyle();
-        const layers = style?.layers || [];
-        layers.forEach(layer => {
-          if (layer.source !== this._sourceId) return;
-          if (
-            typeof mapLayerApi.getLayer !== 'function' ||
-            typeof mapLayerApi.removeLayer !== 'function'
-          ) {
-            return;
-          }
-          let hasLayer = false;
-          try {
-            hasLayer = Boolean(mapLayerApi.getLayer(layer.id));
-          } catch {
-            hasLayer = false;
-          }
-          if (!hasLayer) return;
-          try {
-            mapLayerApi.removeLayer(layer.id);
-          } catch (error) {
-            console.warn(`Failed to remove layer ${layer.id} for source ${this._sourceId}:`, error);
-          }
-        });
-      }
-
-      if (typeof mapSourceApi.getSource === 'function') {
-        let hasSource = false;
-        try {
-          hasSource = Boolean(mapSourceApi.getSource(this._sourceId));
-        } catch {
-          hasSource = false;
-        }
-
-        if (hasSource) {
-          try {
-            map.removeSource(this._sourceId);
-          } catch (error) {
-            console.warn(`Failed to remove source ${this._sourceId}:`, error);
-          }
-        }
-      }
-    } catch (error) {
-      console.warn(`Failed to remove source ${this._sourceId}:`, error);
-    }
+    removeMapSource(this._map, this._sourceId);
   }
 }

--- a/src/Services/FeatureService.ts
+++ b/src/Services/FeatureService.ts
@@ -14,7 +14,12 @@
 
 import * as tilebelt from '@mapbox/tilebelt';
 import tileDecode from 'arcgis-pbf-parser';
-import { cleanTrailingSlash, updateAttribution } from '@/utils';
+import {
+  appendTokenIfExists,
+  cleanTrailingSlash,
+  removeMapSource,
+  updateAttribution,
+} from '@/utils';
 import type {
   Map,
   FeatureServiceOptions,
@@ -258,37 +263,7 @@ export class FeatureService {
    */
   remove(): void {
     this.disableRequests();
-    if (this._map && typeof this._map.removeSource === 'function') {
-      try {
-        // Guard against map whose style has already been destroyed
-        const mapWithStyle = this._map as unknown as {
-          style?: unknown;
-          getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
-        };
-        if (!mapWithStyle.style) return;
-
-        // First, remove any layers that are using this source
-        if (mapWithStyle.getStyle) {
-          const style = mapWithStyle.getStyle();
-          const layers = style?.layers || [];
-          layers.forEach(layer => {
-            if (
-              layer.source === this._sourceId &&
-              this._map.getLayer &&
-              this._map.getLayer(layer.id)
-            ) {
-              this._map.removeLayer(layer.id);
-            }
-          });
-        }
-
-        if (this._map.getSource && this._map.getSource(this._sourceId)) {
-          this._map.removeSource(this._sourceId);
-        }
-      } catch (error) {
-        console.warn(`Failed to remove source ${this._sourceId}:`, error);
-      }
-    }
+    removeMapSource(this._map, this._sourceId);
   }
 
   /** Alias for remove() for API compatibility */
@@ -933,10 +908,7 @@ export class FeatureService {
   }
 
   private _appendTokenIfExists(params: URLSearchParams): void {
-    const token = this._esriServiceOptions.token;
-    if (token) {
-      params.append('token', token);
-    }
+    appendTokenIfExists(params, this._esriServiceOptions.token);
   }
 
   private _getFetchHeaders(): HeadersInit | undefined {

--- a/src/Services/ImageService.ts
+++ b/src/Services/ImageService.ts
@@ -1,4 +1,10 @@
-import { cleanTrailingSlash, getServiceDetails, updateAttribution } from '@/utils';
+import {
+  appendTokenIfExists,
+  cleanTrailingSlash,
+  getServiceDetails,
+  removeMapSource,
+  updateAttribution,
+} from '@/utils';
 import type { Map, ImageServiceOptions, RasterSourceOptions, ServiceMetadata } from '@/types';
 
 interface ImageServiceExtendedOptions extends ImageServiceOptions {
@@ -95,9 +101,7 @@ export class ImageService {
       params.append('mosaicRule', JSON.stringify(this.options.mosaicRule));
     if (this.options.renderingRule)
       params.append('renderingRule', JSON.stringify(this.options.renderingRule));
-    if ((this.esriServiceOptions as any).token) {
-      params.append('token', (this.esriServiceOptions as any).token);
-    }
+    appendTokenIfExists(params, (this.esriServiceOptions as { token?: string }).token);
 
     return {
       type: 'raster',
@@ -214,9 +218,7 @@ export class ImageService {
     });
 
     if (this._time) params.append('time', this._time);
-    if ((this.esriServiceOptions as any).token) {
-      params.append('token', (this.esriServiceOptions as any).token);
-    }
+    appendTokenIfExists(params, (this.esriServiceOptions as { token?: string }).token);
 
     const response = await fetch(
       `${this.esriServiceOptions.url}/identify?${params.toString()}`,
@@ -241,33 +243,6 @@ export class ImageService {
   }
 
   remove(): void {
-    if (this._map && typeof this._map.removeSource === 'function') {
-      try {
-        // Guard against map whose style has already been destroyed
-        const mapWithStyle = this._map as unknown as {
-          style?: unknown;
-          getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
-        };
-        if (!mapWithStyle.style) return;
-
-        // First, remove any layers that are using this source
-        if (mapWithStyle.getStyle) {
-          const style = mapWithStyle.getStyle();
-          const layers = style?.layers || [];
-          layers.forEach(layer => {
-            if (layer.source === this._sourceId && this._map.getLayer(layer.id)) {
-              this._map.removeLayer(layer.id);
-            }
-          });
-        }
-
-        // Then check if source exists before trying to remove it
-        if (this._map.getSource && this._map.getSource(this._sourceId)) {
-          this._map.removeSource(this._sourceId);
-        }
-      } catch (error) {
-        console.warn(`Failed to remove source ${this._sourceId}:`, error);
-      }
-    }
+    removeMapSource(this._map, this._sourceId);
   }
 }

--- a/src/Services/TiledMapService.ts
+++ b/src/Services/TiledMapService.ts
@@ -1,4 +1,4 @@
-import { cleanTrailingSlash, getServiceDetails, updateAttribution } from '@/utils';
+import { cleanTrailingSlash, getServiceDetails, removeMapSource, updateAttribution } from '@/utils';
 import type { Map, EsriServiceOptions, RasterSourceOptions, ServiceMetadata } from '@/types';
 
 interface TiledMapServiceOptions extends EsriServiceOptions {
@@ -114,47 +114,6 @@ export class TiledMapService {
   }
 
   remove(): void {
-    // Guard against disposed or invalid map
-    if (!this._map || typeof this._map.removeSource !== 'function') {
-      return;
-    }
-
-    try {
-      // Guard against map whose style has already been destroyed
-      if (!(this._map as unknown as { style?: unknown }).style) return;
-
-      // First, remove any layers that are using this source
-      const mapWithStyle = this._map as unknown as {
-        getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
-        getLayer?: (id: string) => unknown;
-      };
-
-      if (mapWithStyle.getStyle && typeof mapWithStyle.getLayer === 'function') {
-        const style = mapWithStyle.getStyle();
-        const layers = style?.layers || [];
-        const getLayer = mapWithStyle.getLayer;
-        layers.forEach(layer => {
-          if (layer.source === this._sourceId) {
-            try {
-              if (getLayer(layer.id)) {
-                this._map.removeLayer(layer.id);
-              }
-            } catch {
-              // Layer may already be removed
-            }
-          }
-        });
-      }
-
-      // Then check if source exists before trying to remove it
-      if (typeof this._map.getSource === 'function') {
-        const source = this._map.getSource(this._sourceId);
-        if (source) {
-          this._map.removeSource(this._sourceId);
-        }
-      }
-    } catch (error) {
-      console.warn(`Failed to remove source ${this._sourceId}:`, error);
-    }
+    removeMapSource(this._map, this._sourceId);
   }
 }

--- a/src/Services/VectorTileService.ts
+++ b/src/Services/VectorTileService.ts
@@ -1,4 +1,4 @@
-import { cleanTrailingSlash, getServiceDetails } from '@/utils';
+import { cleanTrailingSlash, getServiceDetails, removeMapSource } from '@/utils';
 import type { Map, VectorTileServiceOptions, VectorSourceOptions, ServiceMetadata } from '@/types';
 
 interface VectorTileServiceExtendedOptions extends VectorTileServiceOptions {
@@ -161,70 +161,6 @@ export class VectorTileService {
   }
 
   remove(): void {
-    const map = this._map;
-    if (!map || typeof map.removeSource !== 'function') {
-      return;
-    }
-
-    try {
-      // Guard against map whose style has already been destroyed
-      if (!(map as unknown as { style?: unknown }).style) return;
-
-      const mapWithStyle = map as unknown as {
-        getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
-      };
-      const mapLayerApi = map as unknown as {
-        getLayer?: (id: string) => unknown;
-        removeLayer?: (id: string) => void;
-      };
-      const mapSourceApi = map as unknown as {
-        getSource?: (id: string) => unknown;
-      };
-
-      if (typeof mapWithStyle.getStyle === 'function') {
-        const style = mapWithStyle.getStyle();
-        const layers = style?.layers || [];
-        layers.forEach(layer => {
-          if (layer.source !== this._sourceId) return;
-          if (
-            typeof mapLayerApi.getLayer !== 'function' ||
-            typeof mapLayerApi.removeLayer !== 'function'
-          ) {
-            return;
-          }
-          let hasLayer = false;
-          try {
-            hasLayer = Boolean(mapLayerApi.getLayer(layer.id));
-          } catch {
-            hasLayer = false;
-          }
-          if (!hasLayer) return;
-          try {
-            mapLayerApi.removeLayer(layer.id);
-          } catch (error) {
-            console.warn(`Failed to remove layer ${layer.id} for source ${this._sourceId}:`, error);
-          }
-        });
-      }
-
-      if (typeof mapSourceApi.getSource === 'function') {
-        let hasSource = false;
-        try {
-          hasSource = Boolean(mapSourceApi.getSource(this._sourceId));
-        } catch {
-          hasSource = false;
-        }
-
-        if (hasSource) {
-          try {
-            map.removeSource(this._sourceId);
-          } catch (error) {
-            console.warn(`Failed to remove source ${this._sourceId}:`, error);
-          }
-        }
-      }
-    } catch (error) {
-      console.warn(`Failed to remove source ${this._sourceId}:`, error);
-    }
+    removeMapSource(this._map, this._sourceId);
   }
 }

--- a/src/react-map-gl/components/EsriDynamicLayer.tsx
+++ b/src/react-map-gl/components/EsriDynamicLayer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
 import { DynamicMapService } from '@/Services/DynamicMapService';
 import type { EsriServiceOptions } from '@/types';
 import type { EsriDynamicLayerProps } from '../types';
 import { useReactMapGL } from '../utils/useReactMapGL';
 import { applyAuthOptions } from '../utils/buildServiceOptions';
+import { useRasterLayer } from '../hooks/useRasterLayer';
 
 /**
  * React Map GL component for Esri Dynamic Map Service
@@ -11,111 +11,39 @@ import { applyAuthOptions } from '../utils/buildServiceOptions';
 export function EsriDynamicLayer(props: EsriDynamicLayerProps) {
   const { current: map } = useReactMapGL();
   const sourceId = props.sourceId || `esri-dynamic-${props.id}`;
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
 
-  // Wait for map to be loaded before creating service
-  useEffect(() => {
-    if (!map) return;
-
-    const mapInstance = map.getMap?.();
-    const mi = mapInstance as any;
-    if (!mi || typeof mi.isStyleLoaded !== 'function') {
-      return;
-    }
-
-    if (mi.isStyleLoaded()) {
-      setIsMapLoaded(true);
-      return;
-    }
-
-    const handleLoad = () => setIsMapLoaded(true);
-    mi?.once?.('load', handleLoad);
-
-    return () => {
-      mi?.off?.('load', handleLoad);
-    };
-  }, [map]);
-
-  const service = useMemo(() => {
-    if (!map || !isMapLoaded) return null;
-
-    const mapInstance = map.getMap?.();
-    if (!mapInstance) return null;
-
-    // Only include defined properties to avoid overriding defaults with undefined
-    const options: EsriServiceOptions & { url: string } = { url: props.url };
-    if (props.layers !== undefined) options.layers = props.layers;
-    if (props.layerDefs !== undefined) options.layerDefs = props.layerDefs;
-    if (props.format !== undefined) options.format = props.format;
-    if (props.dpi !== undefined) options.dpi = props.dpi;
-    if (props.transparent !== undefined) options.transparent = props.transparent;
-    applyAuthOptions(options, props);
-
-    return new DynamicMapService(
-      sourceId,
-      mapInstance as unknown as import('@/types').Map, // Type assertion for map compatibility
-      options
-    );
-  }, [
+  useRasterLayer({
     map,
-    isMapLoaded,
+    layerId: props.id,
     sourceId,
-    props.url,
-    props.layers,
-    props.layerDefs,
-    props.format,
-    props.dpi,
-    props.transparent,
-    props.token,
-    props.apiKey,
-    props.proxy,
-    props.getAttributionFromService,
-    props.requestParams,
-    props.fetchOptions,
-  ]);
+    beforeId: props.beforeId,
+    visible: props.visible,
+    serviceDeps: [
+      props.url,
+      props.layers,
+      props.layerDefs,
+      props.format,
+      props.dpi,
+      props.transparent,
+      props.token,
+      props.apiKey,
+      props.proxy,
+      props.getAttributionFromService,
+      props.requestParams,
+      props.fetchOptions,
+    ],
+    createService: (mapInstance, resolvedSourceId) => {
+      const options: EsriServiceOptions & { url: string } = { url: props.url };
+      if (props.layers !== undefined) options.layers = props.layers;
+      if (props.layerDefs !== undefined) options.layerDefs = props.layerDefs;
+      if (props.format !== undefined) options.format = props.format;
+      if (props.dpi !== undefined) options.dpi = props.dpi;
+      if (props.transparent !== undefined) options.transparent = props.transparent;
+      applyAuthOptions(options, props);
 
-  useEffect(() => {
-    if (!map || !service) return;
-
-    const mapInstance = map.getMap?.() as any;
-    if (
-      !mapInstance ||
-      typeof mapInstance.getLayer !== 'function' ||
-      typeof mapInstance.addLayer !== 'function'
-    ) {
-      return () => {
-        service.remove();
-      };
-    }
-
-    // Add raster layer
-    if (!mapInstance.getLayer(props.id)) {
-      const layerConfig = {
-        id: props.id,
-        type: 'raster' as const,
-        source: sourceId,
-        layout: {
-          visibility: (props.visible !== false ? 'visible' : 'none') as 'visible' | 'none',
-        },
-      };
-
-      if (props.beforeId) {
-        (mapInstance as any).addLayer(layerConfig as any, props.beforeId as any);
-      } else {
-        (mapInstance as any).addLayer(layerConfig as any);
-      }
-    }
-
-    // Cleanup function
-    return () => {
-      if ((mapInstance as any).getStyle?.() && (mapInstance as any).getLayer?.(props.id)) {
-        (mapInstance as any).removeLayer(props.id);
-      }
-      if (service) {
-        service.remove();
-      }
-    };
-  }, [map, service, props.id, props.beforeId, props.visible, sourceId]);
+      return new DynamicMapService(resolvedSourceId, mapInstance, options);
+    },
+  });
 
   return null;
 }

--- a/src/react-map-gl/components/EsriFeatureLayer.tsx
+++ b/src/react-map-gl/components/EsriFeatureLayer.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { FeatureService } from '@/Services/FeatureService';
-import type { FeatureServiceOptions } from '@/types';
+import type { FeatureServiceOptions, Map } from '@/types';
 import type { EsriFeatureLayerProps } from '../types';
 import { useReactMapGL } from '../utils/useReactMapGL';
 import { applyAuthOptions } from '../utils/buildServiceOptions';
+import { useMapLoaded } from '../hooks/useMapLoaded';
+
+type MapLayerApi = {
+  getStyle?: () => unknown;
+  getLayer?: (id: string) => unknown;
+  addLayer?: (layer: unknown, beforeId?: string) => void;
+  removeLayer?: (id: string) => void;
+};
 
 /**
  * React Map GL component for Esri Feature Service
@@ -11,7 +19,7 @@ import { applyAuthOptions } from '../utils/buildServiceOptions';
 export function EsriFeatureLayer(props: EsriFeatureLayerProps) {
   const { current: map } = useReactMapGL();
   const sourceId = props.sourceId || `esri-feature-${props.id}`;
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const isMapLoaded = useMapLoaded(map);
   const serviceRef = useRef<FeatureService | null>(null);
 
   // Keep stable refs for object props to avoid effect re-runs on every render
@@ -20,56 +28,26 @@ export function EsriFeatureLayer(props: EsriFeatureLayerProps) {
   const layoutRef = useRef(props.layout);
   layoutRef.current = props.layout;
 
-  // Wait for map to be loaded before creating service
-  useEffect(() => {
-    if (!map) return;
-
-    const mapInstance = map.getMap?.();
-    const mi = mapInstance as any;
-    if (!mi || typeof mi.isStyleLoaded !== 'function') {
-      return;
-    }
-
-    if (mi.isStyleLoaded()) {
-      setIsMapLoaded(true);
-      return;
-    }
-
-    const handleLoad = () => setIsMapLoaded(true);
-    mi?.once?.('load', handleLoad);
-
-    return () => {
-      mi?.off?.('load', handleLoad);
-    };
-  }, [map]);
-
-  // Create FeatureService, add layer, and clean up on unmount
   useEffect(() => {
     if (!map || !isMapLoaded) return;
 
     const mapInstance = map.getMap?.();
     if (!mapInstance) return;
 
-    const mi = mapInstance as any;
+    const layerApi = mapInstance as unknown as MapLayerApi;
 
-    // Only include defined properties to avoid overriding defaults with undefined
     const options: Partial<FeatureServiceOptions> & { url: string } = { url: props.url };
     if (props.where !== undefined) options.where = props.where;
     if (props.outFields !== undefined) options.outFields = props.outFields;
     applyAuthOptions(options, props);
 
-    const service = new FeatureService(
-      sourceId,
-      mapInstance as unknown as import('@/types').Map,
-      options
-    );
+    const service = new FeatureService(sourceId, mapInstance as unknown as Map, options);
     serviceRef.current = service;
 
-    // Add GeoJSON layer
     if (
-      typeof mi.getLayer === 'function' &&
-      typeof mi.addLayer === 'function' &&
-      !mi.getLayer(props.id)
+      typeof layerApi.getLayer === 'function' &&
+      typeof layerApi.addLayer === 'function' &&
+      !layerApi.getLayer(props.id)
     ) {
       const layerType = props.type || 'fill';
       const defaultPaint =
@@ -88,15 +66,15 @@ export function EsriFeatureLayer(props: EsriFeatureLayerProps) {
       };
 
       if (props.beforeId) {
-        mi.addLayer(layerConfig as any, props.beforeId as any);
+        layerApi.addLayer(layerConfig, props.beforeId);
       } else {
-        mi.addLayer(layerConfig as any);
+        layerApi.addLayer(layerConfig);
       }
     }
 
     return () => {
-      if (mi.getStyle?.() && mi.getLayer?.(props.id)) {
-        mi.removeLayer(props.id);
+      if (layerApi.getStyle?.() && layerApi.getLayer?.(props.id)) {
+        layerApi.removeLayer?.(props.id);
       }
       service.remove();
       serviceRef.current = null;

--- a/src/react-map-gl/components/EsriImageLayer.tsx
+++ b/src/react-map-gl/components/EsriImageLayer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useReactMapGL } from '../utils/useReactMapGL';
 import { ImageService } from '@/Services/ImageService';
 import type { ImageServiceOptions } from '@/types';
 import type { EsriImageLayerProps } from '../types';
+import { useReactMapGL } from '../utils/useReactMapGL';
 import { applyAuthOptions } from '../utils/buildServiceOptions';
+import { useRasterLayer } from '../hooks/useRasterLayer';
 
 /**
  * React Map GL component for Esri Image Service
@@ -11,103 +11,36 @@ import { applyAuthOptions } from '../utils/buildServiceOptions';
 export function EsriImageLayer(props: EsriImageLayerProps) {
   const { current: map } = useReactMapGL();
   const sourceId = props.sourceId || `esri-image-${props.id}`;
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
 
-  // Wait for map to be loaded before creating service
-  useEffect(() => {
-    if (!map) return;
-
-    const mapInstance = map.getMap?.();
-    const mi = mapInstance as any;
-    if (!mi || typeof mi.isStyleLoaded !== 'function') {
-      return;
-    }
-
-    if (mi.isStyleLoaded()) {
-      setIsMapLoaded(true);
-      return;
-    }
-
-    const handleLoad = () => setIsMapLoaded(true);
-    mi?.once?.('load', handleLoad);
-
-    return () => {
-      mi?.off?.('load', handleLoad);
-    };
-  }, [map]);
-
-  const service = useMemo(() => {
-    if (!map || !isMapLoaded) return null;
-
-    const mapInstance = map.getMap?.();
-    if (!mapInstance) return null;
-
-    // Only include defined properties to avoid overriding defaults with undefined
-    const options: Partial<ImageServiceOptions> & { url: string } = { url: props.url };
-    if (props.renderingRule !== undefined) options.renderingRule = props.renderingRule;
-    if (props.mosaicRule !== undefined) options.mosaicRule = props.mosaicRule;
-    if (props.format !== undefined) options.format = props.format as ImageServiceOptions['format'];
-    applyAuthOptions(options, props);
-
-    return new ImageService(sourceId, mapInstance as unknown as import('@/types').Map, options);
-  }, [
+  useRasterLayer({
     map,
-    isMapLoaded,
+    layerId: props.id,
     sourceId,
-    props.url,
-    props.renderingRule,
-    props.mosaicRule,
-    props.format,
-    props.token,
-    props.apiKey,
-    props.proxy,
-    props.getAttributionFromService,
-    props.requestParams,
-    props.fetchOptions,
-  ]);
+    beforeId: props.beforeId,
+    visible: props.visible,
+    serviceDeps: [
+      props.url,
+      props.renderingRule,
+      props.mosaicRule,
+      props.format,
+      props.token,
+      props.apiKey,
+      props.proxy,
+      props.getAttributionFromService,
+      props.requestParams,
+      props.fetchOptions,
+    ],
+    createService: (mapInstance, resolvedSourceId) => {
+      const options: Partial<ImageServiceOptions> & { url: string } = { url: props.url };
+      if (props.renderingRule !== undefined) options.renderingRule = props.renderingRule;
+      if (props.mosaicRule !== undefined) options.mosaicRule = props.mosaicRule;
+      if (props.format !== undefined)
+        options.format = props.format as ImageServiceOptions['format'];
+      applyAuthOptions(options, props);
 
-  useEffect(() => {
-    if (!map || !service) return;
-
-    const mapInstance = map.getMap?.() as any;
-    if (
-      !mapInstance ||
-      typeof mapInstance.getLayer !== 'function' ||
-      typeof mapInstance.addLayer !== 'function'
-    ) {
-      return () => {
-        service.remove();
-      };
-    }
-
-    // Add raster layer
-    if (!mapInstance.getLayer(props.id)) {
-      const layerConfig = {
-        id: props.id,
-        type: 'raster' as const,
-        source: sourceId,
-        layout: {
-          visibility: (props.visible !== false ? 'visible' : 'none') as 'visible' | 'none',
-        },
-      };
-
-      if (props.beforeId) {
-        (mapInstance as any).addLayer(layerConfig as any, props.beforeId as any);
-      } else {
-        (mapInstance as any).addLayer(layerConfig as any);
-      }
-    }
-
-    // Cleanup function
-    return () => {
-      if ((mapInstance as any).getStyle?.() && (mapInstance as any).getLayer?.(props.id)) {
-        (mapInstance as any).removeLayer(props.id);
-      }
-      if (service) {
-        service.remove();
-      }
-    };
-  }, [map, service, props.id, props.beforeId, props.visible, sourceId]);
+      return new ImageService(resolvedSourceId, mapInstance, options);
+    },
+  });
 
   return null;
 }

--- a/src/react-map-gl/components/EsriTiledLayer.tsx
+++ b/src/react-map-gl/components/EsriTiledLayer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
 import { TiledMapService } from '@/Services/TiledMapService';
 import type { EsriServiceOptions } from '@/types';
 import type { EsriTiledLayerProps } from '../types';
 import { useReactMapGL } from '../utils/useReactMapGL';
 import { applyAuthOptions } from '../utils/buildServiceOptions';
+import { useRasterLayer } from '../hooks/useRasterLayer';
 
 /**
  * React Map GL component for Esri Tiled Map Service
@@ -11,96 +11,28 @@ import { applyAuthOptions } from '../utils/buildServiceOptions';
 export function EsriTiledLayer(props: EsriTiledLayerProps) {
   const { current: map } = useReactMapGL();
   const sourceId = props.sourceId || `esri-tiled-${props.id}`;
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
 
-  // Wait for map to be loaded before creating service
-  useEffect(() => {
-    if (!map) return;
-
-    const mapInstance = map.getMap?.();
-    const mi = mapInstance as any;
-    if (!mi || typeof mi.isStyleLoaded !== 'function') {
-      return;
-    }
-
-    if (mi.isStyleLoaded()) {
-      setIsMapLoaded(true);
-      return;
-    }
-
-    const handleLoad = () => setIsMapLoaded(true);
-    mi?.once?.('load', handleLoad);
-
-    return () => {
-      mi?.off?.('load', handleLoad);
-    };
-  }, [map]);
-
-  const service = useMemo(() => {
-    if (!map || !isMapLoaded) return null;
-
-    const mapInstance = map.getMap?.();
-    if (!mapInstance) return null;
-
-    const options: EsriServiceOptions & { url: string } = { url: props.url };
-    applyAuthOptions(options, props);
-
-    return new TiledMapService(sourceId, mapInstance as unknown as import('@/types').Map, options);
-  }, [
+  useRasterLayer({
     map,
-    isMapLoaded,
+    layerId: props.id,
     sourceId,
-    props.url,
-    props.token,
-    props.apiKey,
-    props.proxy,
-    props.getAttributionFromService,
-    props.requestParams,
-    props.fetchOptions,
-  ]);
-
-  useEffect(() => {
-    if (!map || !service) return;
-
-    const mapInstance = map.getMap?.() as any;
-    if (
-      !mapInstance ||
-      typeof mapInstance.getLayer !== 'function' ||
-      typeof mapInstance.addLayer !== 'function'
-    ) {
-      return () => {
-        service.remove();
-      };
-    }
-
-    // Add raster layer
-    if (!mapInstance.getLayer(props.id)) {
-      const layerConfig = {
-        id: props.id,
-        type: 'raster' as const,
-        source: sourceId,
-        layout: {
-          visibility: (props.visible !== false ? 'visible' : 'none') as 'visible' | 'none',
-        },
-      };
-
-      if (props.beforeId) {
-        (mapInstance as any).addLayer(layerConfig as any, props.beforeId as any);
-      } else {
-        (mapInstance as any).addLayer(layerConfig as any);
-      }
-    }
-
-    // Cleanup function
-    return () => {
-      if ((mapInstance as any).getStyle?.() && (mapInstance as any).getLayer?.(props.id)) {
-        (mapInstance as any).removeLayer(props.id);
-      }
-      if (service) {
-        service.remove();
-      }
-    };
-  }, [map, service, props.id, props.beforeId, props.visible, sourceId]);
+    beforeId: props.beforeId,
+    visible: props.visible,
+    serviceDeps: [
+      props.url,
+      props.token,
+      props.apiKey,
+      props.proxy,
+      props.getAttributionFromService,
+      props.requestParams,
+      props.fetchOptions,
+    ],
+    createService: (mapInstance, resolvedSourceId) => {
+      const options: EsriServiceOptions & { url: string } = { url: props.url };
+      applyAuthOptions(options, props);
+      return new TiledMapService(resolvedSourceId, mapInstance, options);
+    },
+  });
 
   return null;
 }

--- a/src/react-map-gl/components/EsriVectorTileLayer.tsx
+++ b/src/react-map-gl/components/EsriVectorTileLayer.tsx
@@ -1,9 +1,28 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { VectorTileService } from '@/Services/VectorTileService';
 import type { EsriVectorTileLayerProps } from '../types';
 import { useReactMapGL } from '../utils/useReactMapGL';
 import type { Map, VectorTileServiceOptions } from '@/types';
 import { applyAuthOptions } from '../utils/buildServiceOptions';
+import { useMapLoaded } from '../hooks/useMapLoaded';
+
+type MapLayerApi = {
+  getStyle?: () => unknown;
+  getLayer?: (id: string) => unknown;
+  addLayer?: (layer: unknown, beforeId?: string) => void;
+  removeLayer?: (id: string) => void;
+};
+
+type VectorStyleLayer = {
+  id: string;
+  type: string;
+  'source-layer'?: string;
+  layout?: Record<string, unknown>;
+  paint?: Record<string, unknown>;
+  filter?: unknown;
+  minzoom?: number;
+  maxzoom?: number;
+};
 
 /**
  * React Map GL component for Esri Vector Tile Service
@@ -11,39 +30,17 @@ import { applyAuthOptions } from '../utils/buildServiceOptions';
 export function EsriVectorTileLayer(props: EsriVectorTileLayerProps) {
   const { current: map } = useReactMapGL();
   const sourceId = props.sourceId || `esri-vector-tile-${props.id}`;
-  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const isMapLoaded = useMapLoaded(map);
   const serviceRef = useRef<VectorTileService | null>(null);
   const layerIdsRef = useRef<string[]>([]);
 
-  // Wait for map to be loaded before creating service
-  useEffect(() => {
-    if (!map) return;
-
-    const mapInstance = map.getMap?.();
-    const mi = mapInstance as any;
-    if (!mi || typeof mi.isStyleLoaded !== 'function') return;
-
-    if (mi.isStyleLoaded()) {
-      setIsMapLoaded(true);
-      return;
-    }
-
-    const handleLoad = () => setIsMapLoaded(true);
-    mi?.once?.('load', handleLoad);
-
-    return () => {
-      mi?.off?.('load', handleLoad);
-    };
-  }, [map]);
-
-  // Create VectorTileService, fetch style, add layers, and clean up on unmount
   useEffect(() => {
     if (!map || !isMapLoaded) return;
 
     const mapInstance = map.getMap?.();
     if (!mapInstance) return;
 
-    const mi = mapInstance as any;
+    const layerApi = mapInstance as unknown as MapLayerApi;
     let cancelled = false;
 
     const options: VectorTileServiceOptions & { url: string } = { url: props.url };
@@ -52,13 +49,11 @@ export function EsriVectorTileLayer(props: EsriVectorTileLayerProps) {
     const service = new VectorTileService(sourceId, mapInstance as unknown as Map, options);
     serviceRef.current = service;
 
-    // Fetch the full style and add all layers from it
     service
       .getStyle()
       .then(() => {
         if (cancelled) return;
 
-        // Fetch the full style document to get all layers
         let styleUrl = `${props.url}/resources/styles/root.json`;
         if (props.token) {
           styleUrl += `?token=${encodeURIComponent(props.token)}`;
@@ -81,13 +76,13 @@ export function EsriVectorTileLayer(props: EsriVectorTileLayerProps) {
         if (cancelled || !data?.layers) return;
 
         const addedIds: string[] = [];
-        for (const layer of data.layers) {
+        for (const layer of data.layers as VectorStyleLayer[]) {
           if (!layer['source-layer']) continue;
           const layerId = `${props.id}-${layer.id}`;
 
-          if (mi.getLayer?.(layerId)) continue;
+          if (layerApi.getLayer?.(layerId)) continue;
 
-          const layerConfig: any = {
+          const layerConfig: Record<string, unknown> = {
             id: layerId,
             type: layer.type,
             source: sourceId,
@@ -99,15 +94,17 @@ export function EsriVectorTileLayer(props: EsriVectorTileLayerProps) {
           if (layer.minzoom !== undefined) layerConfig.minzoom = layer.minzoom;
           if (layer.maxzoom !== undefined) layerConfig.maxzoom = layer.maxzoom;
 
-          // Apply visibility from props
           if (props.visible === false) {
-            layerConfig.layout = { ...layerConfig.layout, visibility: 'none' };
+            layerConfig.layout = {
+              ...((layerConfig.layout as Record<string, unknown>) || {}),
+              visibility: 'none',
+            };
           }
 
           if (props.beforeId) {
-            mi.addLayer(layerConfig, props.beforeId);
+            layerApi.addLayer?.(layerConfig, props.beforeId);
           } else {
-            mi.addLayer(layerConfig);
+            layerApi.addLayer?.(layerConfig);
           }
           addedIds.push(layerId);
         }
@@ -119,11 +116,10 @@ export function EsriVectorTileLayer(props: EsriVectorTileLayerProps) {
 
     return () => {
       cancelled = true;
-      // Remove layers we added
-      if (mi.getStyle?.()) {
+      if (layerApi.getStyle?.()) {
         for (const id of layerIdsRef.current) {
           try {
-            if (mi.getLayer?.(id)) mi.removeLayer(id);
+            if (layerApi.getLayer?.(id)) layerApi.removeLayer?.(id);
           } catch {
             // layer may already be gone
           }

--- a/src/react-map-gl/hooks/createEsriLayerHooks.ts
+++ b/src/react-map-gl/hooks/createEsriLayerHooks.ts
@@ -1,0 +1,36 @@
+import { useDynamicMapService } from '../../react/hooks/useDynamicMapService';
+import { useTiledMapService } from '../../react/hooks/useTiledMapService';
+import { useImageService } from '../../react/hooks/useImageService';
+import { useVectorTileService } from '../../react/hooks/useVectorTileService';
+import { useFeatureService } from '../../react/hooks/useFeatureService';
+import type { Map } from '@/types';
+
+type MapRefLike = { getMap: () => unknown };
+type MapCollection = { current?: MapRefLike | null } | null;
+
+/**
+ * Build the `useEsri{Mapbox,Maplibre}Layer` hook result from a map collection
+ * returned by the corresponding react-map-gl `useMap` hook. Keeps the two
+ * flavors of the hook identical except for the map source.
+ */
+export function createEsriLayerHooks(collection: MapCollection) {
+  // Preserve legacy return shape: `map` is undefined when no ref, the
+  // underlying map otherwise. Child hooks type `map: Map | null`, so we
+  // coerce for the injection below.
+  const map = collection?.current?.getMap?.() as Map | undefined;
+  const injectedMap = (map ?? null) as Map | null;
+
+  return {
+    map,
+    useDynamicMapService: (options: Parameters<typeof useDynamicMapService>[0]) =>
+      useDynamicMapService({ ...options, map: injectedMap }),
+    useTiledMapService: (options: Parameters<typeof useTiledMapService>[0]) =>
+      useTiledMapService({ ...options, map: injectedMap }),
+    useImageService: (options: Parameters<typeof useImageService>[0]) =>
+      useImageService({ ...options, map: injectedMap }),
+    useVectorTileService: (options: Parameters<typeof useVectorTileService>[0]) =>
+      useVectorTileService({ ...options, map: injectedMap }),
+    useFeatureService: (options: Parameters<typeof useFeatureService>[0]) =>
+      useFeatureService({ ...options, map: injectedMap }),
+  };
+}

--- a/src/react-map-gl/hooks/useEsriMapboxLayer.ts
+++ b/src/react-map-gl/hooks/useEsriMapboxLayer.ts
@@ -1,29 +1,10 @@
 import { useMap } from 'react-map-gl/mapbox';
-import { useDynamicMapService } from '../../react/hooks/useDynamicMapService';
-import { useTiledMapService } from '../../react/hooks/useTiledMapService';
-import { useImageService } from '../../react/hooks/useImageService';
-import { useVectorTileService } from '../../react/hooks/useVectorTileService';
-import { useFeatureService } from '../../react/hooks/useFeatureService';
-import type { Map } from '@/types';
+import { createEsriLayerHooks } from './createEsriLayerHooks';
 
 /**
  * Hook for using Esri services with Mapbox GL JS (via react-map-gl)
  */
 export function useEsriMapboxLayer() {
-  const { current: mapRef } = useMap();
-  const map = mapRef?.getMap() as unknown as Map | null;
-
-  return {
-    map,
-    useDynamicMapService: (options: Parameters<typeof useDynamicMapService>[0]) =>
-      useDynamicMapService({ ...options, map }),
-    useTiledMapService: (options: Parameters<typeof useTiledMapService>[0]) =>
-      useTiledMapService({ ...options, map }),
-    useImageService: (options: Parameters<typeof useImageService>[0]) =>
-      useImageService({ ...options, map }),
-    useVectorTileService: (options: Parameters<typeof useVectorTileService>[0]) =>
-      useVectorTileService({ ...options, map }),
-    useFeatureService: (options: Parameters<typeof useFeatureService>[0]) =>
-      useFeatureService({ ...options, map }),
-  };
+  const collection = useMap();
+  return createEsriLayerHooks(collection);
 }

--- a/src/react-map-gl/hooks/useEsriMaplibreLayer.ts
+++ b/src/react-map-gl/hooks/useEsriMaplibreLayer.ts
@@ -1,29 +1,10 @@
 import { useMap } from 'react-map-gl/maplibre';
-import { useDynamicMapService } from '../../react/hooks/useDynamicMapService';
-import { useTiledMapService } from '../../react/hooks/useTiledMapService';
-import { useImageService } from '../../react/hooks/useImageService';
-import { useVectorTileService } from '../../react/hooks/useVectorTileService';
-import { useFeatureService } from '../../react/hooks/useFeatureService';
-import type { Map } from '@/types';
+import { createEsriLayerHooks } from './createEsriLayerHooks';
 
 /**
  * Hook for using Esri services with MapLibre GL JS (via react-map-gl/maplibre)
  */
 export function useEsriMaplibreLayer() {
-  const { current: mapRef } = useMap();
-  const map = mapRef?.getMap() as unknown as Map | null;
-
-  return {
-    map,
-    useDynamicMapService: (options: Parameters<typeof useDynamicMapService>[0]) =>
-      useDynamicMapService({ ...options, map }),
-    useTiledMapService: (options: Parameters<typeof useTiledMapService>[0]) =>
-      useTiledMapService({ ...options, map }),
-    useImageService: (options: Parameters<typeof useImageService>[0]) =>
-      useImageService({ ...options, map }),
-    useVectorTileService: (options: Parameters<typeof useVectorTileService>[0]) =>
-      useVectorTileService({ ...options, map }),
-    useFeatureService: (options: Parameters<typeof useFeatureService>[0]) =>
-      useFeatureService({ ...options, map }),
-  };
+  const collection = useMap();
+  return createEsriLayerHooks(collection);
 }

--- a/src/react-map-gl/hooks/useMapLoaded.ts
+++ b/src/react-map-gl/hooks/useMapLoaded.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import type { ReactMapGLMapRef } from '../utils/useReactMapGL';
+
+type MapWithLoadApi = {
+  isStyleLoaded?: () => boolean;
+  once?: (event: string, handler: () => void) => void;
+  off?: (event: string, handler: () => void) => void;
+};
+
+/**
+ * Returns true once the underlying map's style has finished loading.
+ * Returns false when there is no map yet, the map does not expose the
+ * expected lifecycle API, or the style has not finished loading.
+ */
+export function useMapLoaded(map: ReactMapGLMapRef | null | undefined): boolean {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!map) {
+      setIsLoaded(false);
+      return;
+    }
+
+    const mapInstance = map.getMap?.() as MapWithLoadApi | undefined;
+    if (!mapInstance || typeof mapInstance.isStyleLoaded !== 'function') {
+      setIsLoaded(false);
+      return;
+    }
+
+    if (mapInstance.isStyleLoaded()) {
+      setIsLoaded(true);
+      return;
+    }
+
+    const handleLoad = () => setIsLoaded(true);
+    mapInstance.once?.('load', handleLoad);
+
+    return () => {
+      mapInstance.off?.('load', handleLoad);
+    };
+  }, [map]);
+
+  return isLoaded;
+}

--- a/src/react-map-gl/hooks/useRasterLayer.ts
+++ b/src/react-map-gl/hooks/useRasterLayer.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo } from 'react';
+import type { Map } from '@/types';
+import type { ReactMapGLMapRef } from '../utils/useReactMapGL';
+import { useMapLoaded } from './useMapLoaded';
+
+type RasterService = { remove: () => void };
+
+type MapLayerApi = {
+  getStyle?: () => unknown;
+  getLayer?: (id: string) => unknown;
+  addLayer?: (layer: unknown, beforeId?: string) => void;
+  removeLayer?: (id: string) => void;
+};
+
+export interface UseRasterLayerOptions<TService extends RasterService> {
+  map: ReactMapGLMapRef | null | undefined;
+  layerId: string;
+  sourceId: string;
+  beforeId?: string;
+  visible?: boolean;
+  /**
+   * Dependencies that determine when the service should be rebuilt. The
+   * hook already tracks `map`, the load state, and `sourceId` — callers
+   * should pass any props that affect service construction.
+   */
+  serviceDeps: ReadonlyArray<unknown>;
+  createService: (map: Map, sourceId: string) => TService;
+}
+
+/**
+ * Shared lifecycle for react-map-gl components that wrap an Esri raster
+ * service. Waits for the map style to load, constructs the service, and
+ * adds/removes a raster layer bound to its source.
+ */
+export function useRasterLayer<TService extends RasterService>(
+  options: UseRasterLayerOptions<TService>
+): TService | null {
+  const { map, layerId, sourceId, beforeId, visible, serviceDeps, createService } = options;
+  const isMapLoaded = useMapLoaded(map);
+
+  const service = useMemo<TService | null>(() => {
+    if (!map || !isMapLoaded) return null;
+
+    const mapInstance = map.getMap?.();
+    if (!mapInstance) return null;
+
+    return createService(mapInstance as unknown as Map, sourceId);
+  }, [map, isMapLoaded, sourceId, ...serviceDeps]);
+
+  useEffect(() => {
+    if (!map || !service) return;
+
+    const mapInstance = map.getMap?.() as MapLayerApi | undefined;
+    if (
+      !mapInstance ||
+      typeof mapInstance.getLayer !== 'function' ||
+      typeof mapInstance.addLayer !== 'function'
+    ) {
+      return () => {
+        service.remove();
+      };
+    }
+
+    if (!mapInstance.getLayer(layerId)) {
+      const layerConfig = {
+        id: layerId,
+        type: 'raster' as const,
+        source: sourceId,
+        layout: {
+          visibility: (visible !== false ? 'visible' : 'none') as 'visible' | 'none',
+        },
+      };
+
+      if (beforeId) {
+        mapInstance.addLayer(layerConfig, beforeId);
+      } else {
+        mapInstance.addLayer(layerConfig);
+      }
+    }
+
+    return () => {
+      if (mapInstance.getStyle?.() && mapInstance.getLayer?.(layerId)) {
+        mapInstance.removeLayer?.(layerId);
+      }
+      service.remove();
+    };
+  }, [map, service, layerId, beforeId, visible, sourceId]);
+
+  return service;
+}

--- a/src/react/hooks/useAsyncOperation.ts
+++ b/src/react/hooks/useAsyncOperation.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+
+export interface UseAsyncOperationResult {
+  loading: boolean;
+  error: Error | null;
+  /**
+   * Wrap an async callback with the loading/error state machine shared by
+   * every task-style hook. Rethrows after setting error state so callers
+   * can still `await` and handle failures at the call site.
+   */
+  run: <T>(fn: () => Promise<T>, failureMessage?: string) => Promise<T>;
+}
+
+/**
+ * Shared state + wrapper used by task/editing hooks. Collapses the
+ * repetitive `setLoading(true); try { ... } catch { setError(...) }
+ * finally { setLoading(false) }` dance into one call site.
+ */
+export function useAsyncOperation(): UseAsyncOperationResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const run = useCallback(
+    async <T>(fn: () => Promise<T>, failureMessage = 'Operation failed'): Promise<T> => {
+      setLoading(true);
+      setError(null);
+      try {
+        return await fn();
+      } catch (err) {
+        const errorObj = err instanceof Error ? err : new Error(failureMessage);
+        setError(errorObj);
+        throw errorObj;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { loading, error, run };
+}

--- a/src/react/hooks/useFeatureEditing.ts
+++ b/src/react/hooks/useFeatureEditing.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import type { FeatureService } from '@/Services/FeatureService';
 import type { EditResult, ApplyEditsResult } from '@/types';
+import { useAsyncOperation } from './useAsyncOperation';
 
 export interface UseFeatureEditingResult {
   addFeatures: (
@@ -29,91 +30,46 @@ export interface UseFeatureEditingResult {
  * Hook for feature editing operations on a FeatureService
  */
 export function useFeatureEditing(service: FeatureService | null): UseFeatureEditingResult {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const { loading, error, run } = useAsyncOperation();
   const [lastResult, setLastResult] = useState<EditResult[] | ApplyEditsResult | null>(null);
 
-  const addFeatures = useCallback(
-    async (features: GeoJSON.Feature[], options?: { gdbVersion?: string }) => {
+  const runEdit = useCallback(
+    async <T extends EditResult[] | ApplyEditsResult>(
+      op: () => Promise<T>,
+      failureMessage: string
+    ): Promise<T> => {
       if (!service) throw new Error('FeatureService not available');
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await service.addFeatures(features, options);
-        setLastResult(result);
-        return result;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Add features failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
+      const result = await run(op, failureMessage);
+      setLastResult(result);
+      return result;
     },
-    [service]
+    [service, run]
+  );
+
+  const addFeatures = useCallback(
+    (features: GeoJSON.Feature[], options?: { gdbVersion?: string }) =>
+      runEdit(() => service!.addFeatures(features, options), 'Add features failed'),
+    [service, runEdit]
   );
 
   const updateFeatures = useCallback(
-    async (features: GeoJSON.Feature[], options?: { gdbVersion?: string }) => {
-      if (!service) throw new Error('FeatureService not available');
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await service.updateFeatures(features, options);
-        setLastResult(result);
-        return result;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Update features failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [service]
+    (features: GeoJSON.Feature[], options?: { gdbVersion?: string }) =>
+      runEdit(() => service!.updateFeatures(features, options), 'Update features failed'),
+    [service, runEdit]
   );
 
   const deleteFeatures = useCallback(
-    async (params: { objectIds?: number[]; where?: string }) => {
-      if (!service) throw new Error('FeatureService not available');
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await service.deleteFeatures(params);
-        setLastResult(result);
-        return result;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Delete features failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [service]
+    (params: { objectIds?: number[]; where?: string }) =>
+      runEdit(() => service!.deleteFeatures(params), 'Delete features failed'),
+    [service, runEdit]
   );
 
   const applyEdits = useCallback(
-    async (
+    (
       edits: { adds?: GeoJSON.Feature[]; updates?: GeoJSON.Feature[]; deletes?: number[] },
       options?: { gdbVersion?: string }
-    ) => {
-      if (!service) throw new Error('FeatureService not available');
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await service.applyEdits(edits, options);
-        setLastResult(result);
-        return result;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Apply edits failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [service]
+    ) => runEdit(() => service!.applyEdits(edits, options), 'Apply edits failed'),
+    [service, runEdit]
   );
 
   return {

--- a/src/react/hooks/useFind.ts
+++ b/src/react/hooks/useFind.ts
@@ -1,20 +1,17 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Find } from '@/Tasks/Find';
 import type { UseFindOptions } from '../types';
+import { useAsyncOperation } from './useAsyncOperation';
 
 /**
  * Hook for using Find task
  */
 export function useFind({ url, searchText, layers, searchFields }: UseFindOptions) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const { loading, error, run } = useAsyncOperation();
 
   const find = useCallback(
-    async (additionalOptions?: Record<string, unknown>) => {
-      setLoading(true);
-      setError(null);
-
-      try {
+    (additionalOptions?: Record<string, unknown>) =>
+      run(async () => {
         const findTask = new Find({
           url,
           searchText,
@@ -22,18 +19,9 @@ export function useFind({ url, searchText, layers, searchFields }: UseFindOption
           searchFields,
           ...additionalOptions,
         });
-
-        const results = await findTask.run();
-        return results;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Find failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [url, searchText, layers, searchFields]
+        return findTask.run();
+      }, 'Find failed'),
+    [url, searchText, layers, searchFields, run]
   );
 
   return {

--- a/src/react/hooks/useIdentifyFeatures.ts
+++ b/src/react/hooks/useIdentifyFeatures.ts
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { IdentifyFeatures } from '@/Tasks/IdentifyFeatures';
 import type { Map } from '@/types';
 import type { UseIdentifyFeaturesOptions } from '../types';
+import { useAsyncOperation } from './useAsyncOperation';
 
 /**
  * Hook for using IdentifyFeatures task
@@ -11,18 +12,14 @@ export function useIdentifyFeatures({
   tolerance,
   returnGeometry,
 }: UseIdentifyFeaturesOptions) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const { loading, error, run } = useAsyncOperation();
 
   const identify = useCallback(
-    async (
+    (
       point: { lng: number; lat: number },
       additionalOptions?: Record<string, unknown> & { map?: Map }
-    ) => {
-      setLoading(true);
-      setError(null);
-
-      try {
+    ) =>
+      run(async () => {
         const { map, ...rest } = additionalOptions ?? {};
 
         const identifyTask = new IdentifyFeatures({
@@ -35,17 +32,9 @@ export function useIdentifyFeatures({
         identifyTask.at(point);
         if (map) identifyTask.on(map);
 
-        const results = await identifyTask.run();
-        return results;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Identify failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [url, tolerance, returnGeometry]
+        return identifyTask.run();
+      }, 'Identify failed'),
+    [url, tolerance, returnGeometry, run]
   );
 
   return {

--- a/src/react/hooks/useIdentifyImage.ts
+++ b/src/react/hooks/useIdentifyImage.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { IdentifyImage } from '@/Tasks/IdentifyImage';
 import type { UseIdentifyImageOptions } from '../types';
+import { useAsyncOperation } from './useAsyncOperation';
 
 export interface UseIdentifyImageResult {
   identifyImage: (
@@ -15,17 +16,12 @@ export interface UseIdentifyImageResult {
  * Hook for using IdentifyImage task
  */
 export function useIdentifyImage(options: UseIdentifyImageOptions): UseIdentifyImageResult {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
+  const { loading, error, run } = useAsyncOperation();
   const { url, token, returnGeometry } = options;
 
   const identifyImage = useCallback<UseIdentifyImageResult['identifyImage']>(
-    async (point, additionalOptions) => {
-      setLoading(true);
-      setError(null);
-
-      try {
+    (point, additionalOptions) =>
+      run(async () => {
         const identifyTask = new IdentifyImage({
           ...options,
           ...additionalOptions,
@@ -33,17 +29,9 @@ export function useIdentifyImage(options: UseIdentifyImageOptions): UseIdentifyI
 
         identifyTask.at(point);
 
-        const results = await identifyTask.run();
-        return results;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Identify image failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [url, token, returnGeometry]
+        return identifyTask.run();
+      }, 'Identify image failed'),
+    [url, token, returnGeometry, run]
   );
 
   return {

--- a/src/react/hooks/useQuery.ts
+++ b/src/react/hooks/useQuery.ts
@@ -1,63 +1,38 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Query } from '@/Tasks/Query';
 import type { UseQueryOptions } from '../types';
+import { useAsyncOperation } from './useAsyncOperation';
 
 /**
  * Hook for using Query task
  */
 export function useQuery(options: UseQueryOptions) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-
+  const { loading, error, run } = useAsyncOperation();
   const { url, where, outFields, returnGeometry } = options;
 
   const query = useCallback(
-    async (additionalOptions?: Record<string, unknown>) => {
-      setLoading(true);
-      setError(null);
-
-      try {
+    (additionalOptions?: Record<string, unknown>) =>
+      run(async () => {
         const queryTask = new Query({
           ...options,
           ...additionalOptions,
         });
-
-        const results = await queryTask.run();
-        return results;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Query failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [url, where, outFields, returnGeometry]
+        return queryTask.run();
+      }, 'Query failed'),
+    [url, where, outFields, returnGeometry, run]
   );
 
   const queryAll = useCallback(
-    async (additionalOptions?: Record<string, unknown> & { maxPages?: number }) => {
-      setLoading(true);
-      setError(null);
-
-      try {
+    (additionalOptions?: Record<string, unknown> & { maxPages?: number }) =>
+      run(async () => {
         const { maxPages, ...rest } = additionalOptions || {};
         const queryTask = new Query({
           ...options,
           ...rest,
         });
-
-        const results = await queryTask.runAll({ maxPages });
-        return results;
-      } catch (err) {
-        const errorObj = err instanceof Error ? err : new Error('Query failed');
-        setError(errorObj);
-        throw errorObj;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [url, where, outFields, returnGeometry]
+        return queryTask.runAll({ maxPages });
+      }, 'Query failed'),
+    [url, where, outFields, returnGeometry, run]
   );
 
   return {

--- a/src/tests/Services/ImageService.test.ts
+++ b/src/tests/Services/ImageService.test.ts
@@ -7,6 +7,32 @@ jest.mock('@/utils', () => ({
   cleanTrailingSlash: jest.fn(),
   getServiceDetails: jest.fn(),
   updateAttribution: jest.fn(),
+  appendTokenIfExists: jest.fn((params: URLSearchParams, token?: string) => {
+    if (token) params.append('token', token);
+  }),
+  removeMapSource: jest.fn(
+    (
+      map: {
+        removeSource?: (id: string) => void;
+        getSource?: (id: string) => unknown;
+        getLayer?: (id: string) => unknown;
+        removeLayer?: (id: string) => void;
+        getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
+      } | null,
+      sourceId: string
+    ) => {
+      if (!map || typeof map.removeSource !== 'function') return;
+      const style = map.getStyle?.();
+      (style?.layers || []).forEach(layer => {
+        if (layer.source === sourceId && map.getLayer?.(layer.id)) {
+          map.removeLayer?.(layer.id);
+        }
+      });
+      if (map.getSource?.(sourceId)) {
+        map.removeSource(sourceId);
+      }
+    }
+  ),
 }));
 
 // Mock fetch globally

--- a/src/tests/Services/VectorTileService.test.ts
+++ b/src/tests/Services/VectorTileService.test.ts
@@ -6,6 +6,29 @@ import type { Map, VectorTileServiceOptions, VectorSourceOptions } from '@/types
 jest.mock('@/utils', () => ({
   cleanTrailingSlash: jest.fn(),
   getServiceDetails: jest.fn(),
+  removeMapSource: jest.fn(
+    (
+      map: {
+        removeSource?: (id: string) => void;
+        getSource?: (id: string) => unknown;
+        getLayer?: (id: string) => unknown;
+        removeLayer?: (id: string) => void;
+        getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
+      } | null,
+      sourceId: string
+    ) => {
+      if (!map || typeof map.removeSource !== 'function') return;
+      const style = map.getStyle?.();
+      (style?.layers || []).forEach(layer => {
+        if (layer.source === sourceId && map.getLayer?.(layer.id)) {
+          map.removeLayer?.(layer.id);
+        }
+      });
+      if (map.getSource?.(sourceId)) {
+        map.removeSource(sourceId);
+      }
+    }
+  ),
 }));
 
 // Mock fetch globally

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,80 @@ export function cleanTrailingSlash(url: string): string {
 }
 
 /**
+ * Append a `token` query parameter if a non-empty token is supplied.
+ * Centralizes the duplicated token-injection logic used by every service.
+ */
+export function appendTokenIfExists(params: URLSearchParams, token?: string | null): void {
+  if (token) {
+    params.append('token', token);
+  }
+}
+
+/**
+ * Remove every layer that references the given source, then remove the
+ * source itself. Safe against disposed maps, missing style methods, and
+ * layers that were already removed elsewhere.
+ */
+export function removeMapSource(map: Map | null | undefined, sourceId: string): void {
+  if (!map || typeof map.removeSource !== 'function') return;
+
+  try {
+    if (!(map as unknown as { style?: unknown }).style) return;
+
+    const mapWithStyle = map as unknown as {
+      getStyle?: () => { layers?: Array<{ id: string; source?: string }> };
+      getLayer?: (id: string) => unknown;
+      removeLayer?: (id: string) => void;
+      getSource?: (id: string) => unknown;
+    };
+
+    if (typeof mapWithStyle.getStyle === 'function') {
+      const style = mapWithStyle.getStyle();
+      const layers = style?.layers || [];
+      layers.forEach(layer => {
+        if (layer.source !== sourceId) return;
+        if (
+          typeof mapWithStyle.getLayer !== 'function' ||
+          typeof mapWithStyle.removeLayer !== 'function'
+        ) {
+          return;
+        }
+        let hasLayer = false;
+        try {
+          hasLayer = Boolean(mapWithStyle.getLayer(layer.id));
+        } catch {
+          hasLayer = false;
+        }
+        if (!hasLayer) return;
+        try {
+          mapWithStyle.removeLayer(layer.id);
+        } catch (error) {
+          console.warn(`Failed to remove layer ${layer.id} for source ${sourceId}:`, error);
+        }
+      });
+    }
+
+    if (typeof mapWithStyle.getSource === 'function') {
+      let hasSource = false;
+      try {
+        hasSource = Boolean(mapWithStyle.getSource(sourceId));
+      } catch {
+        hasSource = false;
+      }
+      if (hasSource) {
+        try {
+          map.removeSource(sourceId);
+        } catch (error) {
+          console.warn(`Failed to remove source ${sourceId}:`, error);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to remove source ${sourceId}:`, error);
+  }
+}
+
+/**
  * Check if an error represents an AbortError (request was cancelled)
  * Handles various error shapes from different browsers and environments
  */


### PR DESCRIPTION
## Summary
- Extract the repeated "wait for map style load" + "create service + add raster layer + cleanup" logic from `EsriDynamicLayer`, `EsriTiledLayer`, `EsriImageLayer` into two shared hooks: `useMapLoaded` and `useRasterLayer`.
- Also apply `useMapLoaded` in `EsriFeatureLayer` and `EsriVectorTileLayer` so the five layer components share one load-gate implementation.
- Collapse `useEsriMapboxLayer` and `useEsriMaplibreLayer` onto a single `createEsriLayerHooks` factory — the two files only differed by which `useMap` they imported.
- Add `appendTokenIfExists` and `removeMapSource` helpers in `src/utils.ts` and wire them into `DynamicMapService`, `TiledMapService`, `ImageService`, `VectorTileService`, and `FeatureService`. Each of their `remove()` methods was a ~40-line copy of the same "iterate style layers, remove matching, then remove source" dance.

## Impact
- **-367 net lines** across layer components + services.
- Test suite: 733 / 733 passing (unchanged).
- Lint: 1 error → 0 errors, 72 warnings → 29 warnings (consolidated code eliminated duplicate `any` usages).
- Build: `npm run build` still green.
- No public API changes — component props, hook signatures, and service method signatures are all preserved.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` (all 733 tests pass)
- [x] `npm run build`
- [ ] Smoke-test a consuming app (e.g. the demo) to confirm layer behavior is unchanged at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)